### PR TITLE
Non functioning ncurses binding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,9 @@ kotlin {
     }
 
     luciferTarget.apply {
-        compilations["main"].enableEndorsedLibs = false
+        compilations["main"].cinterops {
+            val ncurses by creating
+        }
         binaries {
             executable(listOf(DEBUG, RELEASE)) {
                 entryPoint = "main"
@@ -30,11 +32,7 @@ kotlin {
         }
     }
     sourceSets {
-        val luciferMain by getting {
-            dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-cli:0.3.4")
-            }
-        }
+        val luciferMain by getting
         val luciferTest by getting
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 kotlin.code.style=official
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+kotlin.native.cacheKind.linuxX64=none
+

--- a/src/luciferMain/kotlin/Main.kt
+++ b/src/luciferMain/kotlin/Main.kt
@@ -9,7 +9,7 @@ fun main(args: Array<String>) {
     val bufferLen = 4096
     val buffer = ByteArray(bufferLen)
 
-    // TODO brutal hack for now. there is an arg parser available in kotlinx, but it adds 1MB to the compiled binary
+    // TODO brutal hack for now. there is an arg parser available in kotlinx, but it adds 500KB to the compiled binary!
     val debug = args.contains("--debug")
     val err = args.contains("--err")
     val noformat = args.contains("--noformat")
@@ -18,6 +18,7 @@ fun main(args: Array<String>) {
     }.map {
         it.substring(10)
     }
+    val curses = args.contains("--curses")
 
     val parser = LSOFParser(debug)
     var lineState: Pair<ParseState, ProcessRecord?> = ParseState.new() to null
@@ -58,23 +59,27 @@ fun main(args: Array<String>) {
             }
 
             spinner.clear()
-            val reporter = LSOFReporter(UserResolver(buffer), parser.yieldData(), !noformat)
-            // summarization mode
-            if (processes.isEmpty()) {
-                reporter.byProcessReport()
-                println()
-                reporter.fileTypeUserReport()
-                println()
-                reporter.networkConnectionsReport()
-            // detail mode for specific processes
-            } else {
-                processes.forEach {
-                    reporter.processReport(it.toInt())
-                    println()
-                }
-            }
 
-            break
+            if (curses) {
+
+            } else {
+                val reporter = LSOFReporter(UserResolver(buffer), parser.yieldData(), !noformat)
+                // summarization mode
+                if (processes.isEmpty()) {
+                    reporter.byProcessReport()
+                    println()
+                    reporter.fileTypeUserReport()
+                    println()
+                    reporter.networkConnectionsReport()
+                    // detail mode for specific processes
+                } else {
+                    processes.forEach {
+                        reporter.processReport(it.toInt())
+                        println()
+                    }
+                }
+                break
+            }
         }
     }
 }

--- a/src/luciferMain/kotlin/curses/HelloWorld.kt
+++ b/src/luciferMain/kotlin/curses/HelloWorld.kt
@@ -1,0 +1,31 @@
+package curses
+
+import kotlinx.cinterop.CPointer
+import ncurses.*
+import platform.posix.sleep
+
+fun initWindow() = initscr() ?: throw RuntimeException("Error initialising ncurses.")
+
+fun cleanUp(window: CPointer<WINDOW>) {
+    delwin(window)
+    endwin()
+    refresh()
+}
+
+fun showHelloWorld() {
+    mvaddstr(13, 33, "Hello, world!")
+    refresh()
+    sleep(3)
+}
+
+fun main() {
+    println("starting ncurses ...")
+
+    initWindow().apply {
+        try {
+            showHelloWorld()
+        } finally {
+            cleanUp(this)
+        }
+    }
+}

--- a/src/nativeInterop/cinterop/ncurses.def
+++ b/src/nativeInterop/cinterop/ncurses.def
@@ -1,0 +1,4 @@
+headers = curses.h
+headerFilter = curses.h
+compilerOpts = -I/usr/include -I/usr/include/ncurses
+linkerOpts.linux = -L/usr/lib64 -L/usr/lib/x86_64-linux-gnu -lncurses


### PR DESCRIPTION
Based on example: https://github.com/sobotkami/kotlin-native-ncurses

This currently fails compilation with:

```
./build.sh

> Configure project :
Kotlin Multiplatform Projects are an Alpha feature. See: https://kotlinlang.org/docs/reference/evolution/components-stability.html. To hide this message, add 'kotlin.mpp.stability.nowarn=true' to the Gradle properties.


> Task :cinteropNcursesLucifer FAILED
Exception in thread "main" java.lang.Error: /usr/include/stdint.h:26:10: fatal error: 'bits/libc-header-start.h' file not found
        at org.jetbrains.kotlin.native.interop.indexer.UtilsKt.ensureNoCompileErrors(Utils.kt:192)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.indexDeclarations(Indexer.kt:1189)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.buildNativeIndexImpl(Indexer.kt:1178)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.buildNativeIndexImpl(Indexer.kt:1174)
        at org.jetbrains.kotlin.native.interop.gen.jvm.DefaultPlugin.buildNativeIndex(Plugins.kt:31)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.processCLib(main.kt:272)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.interop(main.kt:76)
        at org.jetbrains.kotlin.cli.utilities.InteropCompilerKt.invokeInterop(InteropCompiler.kt:45)
        at org.jetbrains.kotlin.cli.utilities.MainKt.mainImpl(main.kt:38)
        at org.jetbrains.kotlin.cli.utilities.MainKt.main(main.kt:60)

FAILURE: Build failed with an exception.

```

